### PR TITLE
Fix CUDA error when running controlled Pauli rots on GPU

### DIFF
--- a/pyqtorch/core/batched_operation.py
+++ b/pyqtorch/core/batched_operation.py
@@ -431,7 +431,7 @@ def batchedCRX(
     operations_batch = get_parametrized_batch_for_operation("X", theta, batch_size, dev)
     controlledX_batch = create_controlled_batch_from_operation(operations_batch, batch_size)
 
-    return _apply_batch_gate(state, controlledX_batch, qubits, N_qubits, batch_size)
+    return _apply_batch_gate(state, controlledX_batch.to(dev), qubits, N_qubits, batch_size)
 
 
 def batchedCRY(
@@ -467,7 +467,7 @@ def batchedCRY(
     operations_batch = get_parametrized_batch_for_operation("Y", theta, batch_size, dev)
     controlledX_batch = create_controlled_batch_from_operation(operations_batch, batch_size)
 
-    return _apply_batch_gate(state, controlledX_batch, qubits, N_qubits, batch_size)
+    return _apply_batch_gate(state, controlledX_batch.to(dev), qubits, N_qubits, batch_size)
 
 
 def batchedCRZ(
@@ -503,7 +503,7 @@ def batchedCRZ(
     operations_batch = get_parametrized_batch_for_operation("Z", theta, batch_size, dev)
     controlledX_batch = create_controlled_batch_from_operation(operations_batch, batch_size)
 
-    return _apply_batch_gate(state, controlledX_batch, qubits, N_qubits, batch_size)
+    return _apply_batch_gate(state, controlledX_batch.to(dev), qubits, N_qubits, batch_size)
 
 
 def batched_hamiltonian_evolution(


### PR DESCRIPTION
PR to fix following error when attempting to run a circuit with `CRY` gates in on GPU:

```
lib/python3.10/site-packages/torch/functional.py", line 378, in einsum
    return _VF.einsum(equation, operands)  # type: ignore[attr-defined]
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! (when checking argument for argument mat2 in method wrapper_bmm)
```

Not familiar with the codebase, reviewers feel free to add appropriate unit tests if needed (and possible to tests against specific backends).