### PR TITLE
Remove device attribute from gates

### DIFF
--- a/pyqtorch/modules/circuit.py
+++ b/pyqtorch/modules/circuit.py
@@ -40,12 +40,14 @@ class QuantumCircuit(Module):
         return state
 
     @property
-    def device(self) -> torch.device:
-        devices = set(op.device for op in self.operations)
-        if len(devices) == 1:
+    def _device(self) -> torch.device:
+        devices = set(p.device for p in self.parameters())
+        if len(devices) == 0:
+            return torch.device("cpu")
+        elif len(devices) == 1:
             return devices.pop()
         else:
             raise ValueError("only one device supported.")
 
     def init_state(self, batch_size: int) -> torch.Tensor:
-        return zero_state(self.n_qubits, batch_size, device=self.device)
+        return zero_state(self.n_qubits, batch_size, device=self._device)

--- a/pyqtorch/modules/hamevo.py
+++ b/pyqtorch/modules/hamevo.py
@@ -49,10 +49,6 @@ class HamEvo(torch.nn.Module):
     def forward(self, state: torch.Tensor) -> torch.Tensor:
         return self.apply(state)
 
-    @property
-    def device(self) -> torch.device:
-        return self.H.device
-
 
 @lru_cache(maxsize=256)
 def diagonalize(H: torch.Tensor) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:

--- a/pyqtorch/modules/parametric.py
+++ b/pyqtorch/modules/parametric.py
@@ -36,10 +36,6 @@ class RotationGate(Module):
         mats = self.matrices(thetas)
         return self.apply(mats, state)
 
-    @property
-    def device(self) -> torch.device:
-        return self.imat.device
-
     def extra_repr(self) -> str:
         return f"'{self.gate}', {self.qubits}, {self.n_qubits}, '{self.param_name}'"
 

--- a/pyqtorch/modules/primitive.py
+++ b/pyqtorch/modules/primitive.py
@@ -27,10 +27,6 @@ class PrimitiveGate(Module):
     def forward(self, _: dict[str, torch.Tensor], state: torch.Tensor) -> torch.Tensor:
         return self.apply(self.matrix, state)
 
-    @property
-    def device(self) -> torch.device:
-        return self.matrix.device
-
     def extra_repr(self) -> str:
         return f"'{self.gate}', {self.qubits}, {self.n_qubits}"
 
@@ -80,10 +76,6 @@ class ControlledOperationGate(Module):
 
     def forward(self, _: dict[str, torch.Tensor], state: torch.Tensor) -> torch.Tensor:
         return _apply_gate(state, self.matrix, self.qubits, self.n_qubits)
-
-    @property
-    def device(self) -> torch.device:
-        return self.matrix.device
 
     def extra_repr(self) -> str:
         return f"'{self.gate}', {self.qubits}, {self.n_qubits}"


### PR DESCRIPTION
Infer device for initial state creation from `model.parameters` directly and don't go via a custom `model.device` property in every gate.