### PR TITLE
Add hamevo with torch.linalg.matrix_exp

### DIFF
--- a/pyqtorch/modules/__init__.py
+++ b/pyqtorch/modules/__init__.py
@@ -8,6 +8,6 @@ from pyqtorch.modules.circuit import (
     uniform_state,
     zero_state,
 )
-from pyqtorch.modules.hamevo import HamEvo, HamEvoEig
+from pyqtorch.modules.hamevo import HamEvo, HamEvoEig, HamEvoExp
 from pyqtorch.modules.parametric import CPHASE, CRX, CRY, CRZ, RX, RY, RZ, U
 from pyqtorch.modules.primitive import CNOT, SWAP, H, I, S, T, X, Y, Z

--- a/pyqtorch/modules/hamevo.py
+++ b/pyqtorch/modules/hamevo.py
@@ -89,7 +89,8 @@ class HamEvoEig(HamEvo):
         self.l_vec = []
         self.l_val = []
         for i in range(batch_size_h):
-            eig_values, eig_vectors = diagonalize(self.H[..., [i]])
+            eig_values, eig_vectors = diagonalize(self.H[..., i])
+
             self.l_vec.append(eig_vectors)
             self.l_val.append(eig_values)
 
@@ -110,7 +111,6 @@ class HamEvoEig(HamEvo):
 
         for i in range(batch_size_h):
             eig_values, eig_vectors = self.l_val[i], self.l_vec[i]
-            eig_values = eig_values.flatten(0)
 
             if eig_vectors is None:
                 # Compute e^(-i H t)

--- a/pyqtorch/modules/utils.py
+++ b/pyqtorch/modules/utils.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import torch
+
+
+def is_diag(H: torch.Tensor) -> bool:
+    """
+    Returns True if Hamiltonian H is diagonal.
+    """
+    return len(torch.abs(torch.triu(H, diagonal=1)).to_sparse().coalesce().values()) == 0
+
+
+def is_real(H: torch.Tensor) -> bool:
+    """
+    Returns True if Hamiltonian H is real.
+    """
+    return len(torch.imag(H).to_sparse().coalesce().values()) == 0

--- a/tests/test_module_hamevo.py
+++ b/tests/test_module_hamevo.py
@@ -41,7 +41,7 @@ def Hamiltonian(batch_size: int = 1) -> torch.Tensor:
 
 @pytest.mark.parametrize(
     "ham_evo",
-    [pyq.HamEvo, pyq.HamEvoEig],
+    [pyq.HamEvo, pyq.HamEvoEig, pyq.HamEvoExp],
 )
 def test_hamevo_modules_single(ham_evo: torch.nn.Module) -> None:
     n_qubits = 4
@@ -57,7 +57,7 @@ def test_hamevo_modules_single(ham_evo: torch.nn.Module) -> None:
 
 @pytest.mark.parametrize(
     "ham_evo",
-    [pyq.HamEvo, pyq.HamEvoEig],
+    [pyq.HamEvo, pyq.HamEvoEig, pyq.HamEvoExp],
 )
 def test_hamevo_modules_batch(ham_evo: torch.nn.Module) -> None:
     n_qubits = 4


### PR DESCRIPTION
Current hamevo with diagonalization has unstable gradients in some optimization routines. Using `torch.linalg.matrix_exp` seems to be quite fast and should solve the unstable gradients.

- [x] Add first module
- [x] Include diagonal check not to run matrix_exp on diagonal hamiltonians
- [x] Add more unit tests