### PR TITLE
[BugFix] Fix type inference error.

### DIFF
--- a/pyqtorch/core/utils.py
+++ b/pyqtorch/core/utils.py
@@ -77,7 +77,9 @@ def _apply_gate(
 
     state = torch.tensordot(mat, state, dims=axes)
     inv_perm = torch.argsort(
-        torch.tensor(state_dims + [j for j in range(N_qubits + 1) if j not in state_dims])
+        torch.tensor(
+            state_dims + [j for j in range(N_qubits + 1) if j not in state_dims], dtype=torch.int
+        )
     )
     state = torch.permute(state, tuple(inv_perm))
     return state


### PR DESCRIPTION
This PR addresses the addition of a data type to correctly infer the type. This avoids errors:

```python
>           torch.tensor(state_dims + [j for j in range(N_qubits + 1) if j not in state_dims])
        )
E       RuntimeError: Could not infer dtype of Zero
```