### PR TITLE
Correct tensor type

### DIFF
--- a/pyqtorch/core/utils.py
+++ b/pyqtorch/core/utils.py
@@ -152,7 +152,7 @@ def _apply_batch_gate(
     Same shape as `input_state`
     """
     mat = mat.reshape([2] * len(qubits) * 2 + [batch_size])
-    qubits = N_qubits - 1 - np.array(qubits)
+    qubits = np.array(N_qubits - 1 - np.array(qubits), dtype=np.int64)
 
     state_indices = ABC_ARRAY[0 : N_qubits + 1].copy()
     mat_indices = ABC_ARRAY[N_qubits + 2 : N_qubits + 2 + 2 * len(qubits) + 1].copy()

--- a/pyqtorch/core/utils.py
+++ b/pyqtorch/core/utils.py
@@ -77,7 +77,9 @@ def _apply_gate(
 
     state = torch.tensordot(mat, state, dims=axes)
     inv_perm = torch.argsort(
-        torch.tensor(state_dims + [j for j in range(N_qubits + 1) if j not in state_dims])
+        torch.tensor(
+            state_dims + [j for j in range(N_qubits + 1) if j not in state_dims], dtype=torch.int
+        )
     )
     state = torch.permute(state, tuple(inv_perm))
     return state


### PR DESCRIPTION
Another PR in the same vein: specifying `dtype` to avoid errors:

```python
>       mat_indices[len(qubits) : 2 * len(qubits)] = state_indices[qubits]
E
```

because:

```
qubits = array([0], dtype=object)
```