### PR TITLE
`HamEvo` endianness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 requires-python = ">=3.8,<3.12"
 license = {text = "Proprietary"}
-version = "0.3.3"
+version = "0.4.0"
 classifiers=[
     "License :: Other/Proprietary License",
     "Programming Language :: Python",

--- a/pyqtorch/modules/hamevo.py
+++ b/pyqtorch/modules/hamevo.py
@@ -33,7 +33,7 @@ class HamEvo(torch.nn.Module):
         super().__init__()
         self.H: torch.Tensor
         self.t: torch.Tensor
-        self.qubits = qubits
+        self.qubits = [n_qubits - i - 1 for i in qubits]
         self.n_qubits = n_qubits
         self.n_steps = n_steps
         if H.ndim == 2:
@@ -298,7 +298,7 @@ class HamiltonianEvolution(Module):
         hamevo_type: Union[HamEvoType, str] = HamEvoType.EXP,
     ):
         super().__init__()
-        self.qubits = [n_qubits - i - 1 for i in qubits]
+        self.qubits = qubits
         self.n_qubits = n_qubits
         self.n_steps = n_steps
 

--- a/pyqtorch/modules/hamevo.py
+++ b/pyqtorch/modules/hamevo.py
@@ -298,7 +298,7 @@ class HamiltonianEvolution(Module):
         hamevo_type: Union[HamEvoType, str] = HamEvoType.EXP,
     ):
         super().__init__()
-        self.qubits = qubits
+        self.qubits = [n_qubits - i - 1 for i in qubits]
         self.n_qubits = n_qubits
         self.n_steps = n_steps
 

--- a/tests/test_module_hamevo.py
+++ b/tests/test_module_hamevo.py
@@ -224,16 +224,33 @@ def test_hamiltonianevolution_with_types(
 
 
 def test_hamevo_endianness() -> None:
-    m = torch.rand(2,2)
-    i = torch.eye(2)
-    h = torch.kron(m, i)
-    t = torch.ones(1)
+    # m = torch.rand(2,2)
+    # i = torch.eye(2)
+    # h = torch.kron(m, i)
 
-    op = pyq.HamEvoExp(h, t, qubits=[0,1], n_qubits=2)
+    t = torch.ones(1)
+    h = torch.tensor(
+        [
+            [0.9701, 0.0000, 0.7078, 0.0000],
+            [0.0000, 0.9701, 0.0000, 0.7078],
+            [0.4594, 0.0000, 0.9207, 0.0000],
+            [0.0000, 0.4594, 0.0000, 0.9207],
+        ]
+    )
+    iszero = torch.tensor([False, True, False, True])
+    op = pyq.HamEvoExp(h, t, qubits=[0, 1], n_qubits=2)
     st = op(pyq.zero_state(2)).flatten()
-    print(st)
-    mask = torch.isclose(st, torch.zero(1))
-    print(mask)
-    raise
-    assert not torch.allclose(st[0,2], 0)
-    raise
+    assert torch.allclose(st[iszero], torch.zeros(1, dtype=torch.cdouble))
+
+    h = torch.tensor(
+        [
+            [0.9701, 0.7078, 0.0000, 0.0000],
+            [0.4594, 0.9207, 0.0000, 0.0000],
+            [0.0000, 0.0000, 0.9701, 0.7078],
+            [0.0000, 0.0000, 0.4594, 0.9207],
+        ]
+    )
+    iszero = torch.tensor([False, False, True, True])
+    op = pyq.HamEvoExp(h, t, qubits=[0, 1], n_qubits=2)
+    st = op(pyq.zero_state(2)).flatten()
+    assert torch.allclose(st[iszero], torch.zeros(1, dtype=torch.cdouble))

--- a/tests/test_module_hamevo.py
+++ b/tests/test_module_hamevo.py
@@ -224,10 +224,6 @@ def test_hamiltonianevolution_with_types(
 
 
 def test_hamevo_endianness() -> None:
-    # m = torch.rand(2,2)
-    # i = torch.eye(2)
-    # h = torch.kron(m, i)
-
     t = torch.ones(1)
     h = torch.tensor(
         [

--- a/tests/test_module_hamevo.py
+++ b/tests/test_module_hamevo.py
@@ -126,7 +126,6 @@ def test_hamevo_modules_batch(ham_evo: torch.nn.Module) -> None:
     psi = pyq.uniform_state(n_qubits, batch_size)
     psi_star = hamevo.forward(psi)
     result = overlap(psi_star, psi)
-    print(result)
 
     assert map(isclose, zip(result, [0.5, 0.5]))  # type: ignore [arg-type]
 
@@ -222,3 +221,19 @@ def test_hamiltonianevolution_with_types(
     result = overlap(psi_star, psi)
     assert result.size() == (batch_size,)
     assert torch.allclose(result, target)
+
+
+def test_hamevo_endianness() -> None:
+    m = torch.rand(2,2)
+    i = torch.eye(2)
+    h = torch.kron(m, i)
+    t = torch.ones(1)
+
+    op = pyq.HamEvoExp(h, t, qubits=[0,1], n_qubits=2)
+    st = op(pyq.zero_state(2)).flatten()
+    print(st)
+    mask = torch.isclose(st, torch.zero(1))
+    print(mask)
+    raise
+    assert not torch.allclose(st[0,2], 0)
+    raise


### PR DESCRIPTION
hamevo has incorrect endianness... as shown below. this PR fixes this with a bit of a hacky endianness inversion in `HamEvo`...

```python
op = pyq.HamEvoExp(H0, torch.tensor([1.0]), qubits=[0,1], n_qubits=2)
print(H0)
# tensor([[0.2170+0.3727j, 0.4376+0.4428j, 0.0000+0.0000j, 0.0000+0.0000j],
        # [0.7258+0.9817j, 0.0201+0.0922j, 0.0000+0.0000j, 0.0000+0.0000j],
        # [0.0000+0.0000j, 0.0000+0.0000j, 0.2170+0.3727j, 0.4376+0.4428j],
        # [0.0000+0.0000j, 0.0000+0.0000j, 0.7258+0.9817j, 0.0201+0.0922j]])
print(op(pyq.zero_state(2)).flatten())
# tensor([1.3867-0.8201j, 0.0000+0.0000j, 1.0011-1.2202j, 0.0000+0.0000j])
# i would expect this
# tensor([1.3867-0.8201j, 1.0011-1.2202j, 0.0000+0.0000j, 0.0000+0.0000j])


op = pyq.HamEvoExp(H1, torch.tensor([1.0]), qubits=[0,1], n_qubits=2)
print(H1)
# tensor([[0.2170+0.3727j, 0.0000+0.0000j, 0.4376+0.4428j, 0.0000+0.0000j],
        # [0.0000+0.0000j, 0.2170+0.3727j, 0.0000+0.0000j, 0.4376+0.4428j],
        # [0.7258+0.9817j, 0.0000+0.0000j, 0.0201+0.0922j, 0.0000+0.0000j],
        # [0.0000+0.0000j, 0.7258+0.9817j, 0.0000+0.0000j, 0.0201+0.0922j]])
print(op(pyq.zero_state(2)).flatten())
# tensor([1.3867-0.8201j, 1.0011-1.2202j, 0.0000+0.0000j, 0.0000+0.0000j])
# I would expect this
# tensor([1.3867-0.8201j, 0.0000+0.0000j, 1.0011-1.2202j, 0.0000+0.0000j])
```