### PR TITLE
[UnitaryHack] Optimize Krylov solver for batched calculations

### DIFF
--- a/pyqtorch/time_dependent/integrators/krylov.py
+++ b/pyqtorch/time_dependent/integrators/krylov.py
@@ -31,15 +31,13 @@ class KrylovIntegrator:
 
     def run(self) -> Tensor:
 
-        out = []
-        for i in range(self.y0.shape[1]):
-            # run the Krylov routine
-            result = []
-            y = self.y0[:, i : i + 1]
-            t = self.t0
-            for tnext in self.tsave:
-                y = self.integrate(t, tnext, y)
-                result.append(y.T)
-                t = tnext
-            out.append(torch.cat(result))
-        return torch.stack(out, dim=2)
+        # run the Krylov routine
+        result = []
+        y = self.y0
+        t = self.t0
+        for tnext in self.tsave:
+            y = self.integrate(t, tnext, y)
+            result.append(y)
+            t = tnext
+
+        return torch.stack(result, dim=0)

--- a/pyqtorch/time_dependent/methods/krylov.py
+++ b/pyqtorch/time_dependent/methods/krylov.py
@@ -21,59 +21,75 @@ class Krylov(KrylovIntegrator):
         state: Tensor,
     ) -> Tensor:
 
+        # ensure Krylov solver is passed only 2D tensors
+        if state.ndim != 2:
+            raise ValueError(
+                f"Krylov solver expects a 2D state tensor with a batch dimension"
+                f" at index 1 (expected state.ndim == 2; got state.ndim == {state.ndim})."
+            )
+
+        # move trailing batch dimension to leading batch dimension
+        state = state.T.unsqueeze(-1)
+
         def exponentiate() -> tuple[torch.Tensor, bool]:
             # approximate next iteration by modifying T, and unmodifying
-            T[i - 1, i] = 0
-            T[i + 1, i] = 1
-            exp = torch.linalg.matrix_exp(-1j * dt * T[: i + 2, : i + 2].clone())
-            T[i - 1, i] = T[i, i - 1]
-            T[i + 1, i] = 0
+            T[:, i - 1, i] = 0
+            T[:, i + 1, i] = 1
+            exp = torch.linalg.matrix_exp(-1j * dt * T[:, : i + 2, : i + 2].clone())
+            T[:, i - 1, i] = T[:, i, i - 1]
+            T[:, i + 1, i] = 0
 
-            e1 = abs(exp[i, 0])
-            e2 = abs(exp[i + 1, 0]) * n
-            if e1 > 10 * e2:
-                error = e2
-            elif e2 > e1:
-                error = e1
-            else:
-                error = (e1 * e2) / (e1 - e2)
+            # compute errors
+            e1 = abs(exp[:, i, 0])
+            e2 = abs(exp[:, i + 1, 0]) * n
 
-            converged = error < self.options.exp_tolerance
-            return exp[:, 0], converged
+            # compute batch convergence error
+            error = (e1 * e2) / (e1 - e2)
+            use_e2_idx = e1 > 10 * e2
+            use_e1_idx = e2 > e1
+            error[use_e2_idx] = e2[use_e2_idx]
+            error[use_e1_idx] = e1[use_e1_idx]
+
+            # set convergence criteria based on maximum error in batch
+            converged = error.max() < self.options.exp_tolerance
+            return exp[:, :, 0], converged
 
         lanczos_vectors = [state]
         T = torch.zeros(
-            self.options.max_krylov + 1, self.options.max_krylov + 1, dtype=state.dtype
+            (state.shape[0], self.options.max_krylov + 1, self.options.max_krylov + 1),
+            dtype=state.dtype,
         )
 
         # step 0 of the loop
         v = torch.matmul(self.H(t), state)
-        a = torch.matmul(v.conj().T, state)
-        n = torch.linalg.vector_norm(v)
-        T[0, 0] = a
+        a = torch.matmul(v.conj().mT, state)
+        n = torch.linalg.vector_norm(v.squeeze(2), dim=1)
+        T[:, 0, 0] = a.squeeze((1, 2))
         v = v - a * state
 
         for i in range(1, self.options.max_krylov):
+
             # this block should not be executed in step 0
-            b = torch.linalg.vector_norm(v)
-            if b < self.options.norm_tolerance:
-                exp = torch.linalg.matrix_exp(-1j * dt * T[:i, :i])
-                weights = exp[:, 0]
+            b = torch.linalg.vector_norm(v.squeeze(2), dim=1).view(-1, 1, 1)
+            if b.max() < self.options.norm_tolerance:
+                exp = torch.linalg.matrix_exp(-1j * dt * T[:, :i, :i])
+                weights = exp[:, :, 0]
                 converged = True
                 break
 
-            T[i, i - 1] = b
-            T[i - 1, i] = b
-            state = v / b
+            T[:, i, i - 1] = b.squeeze((1, 2))
+            T[:, i - 1, i] = b.squeeze((1, 2))
+            state = v / b.view(-1, 1, 1)
+
             lanczos_vectors.append(state)
             weights, converged = exponentiate()
             if converged:
                 break
 
             v = torch.matmul(self.H(t), state)
-            a = torch.matmul(v.conj().T, state)
-            n = torch.linalg.vector_norm(v)
-            T[i, i] = a
+            a = torch.matmul(v.conj().mT, state)
+            n = torch.linalg.vector_norm(v.squeeze(2), dim=1)
+            T[:, i, i] = a.squeeze((1, 2))
             v = v - a * lanczos_vectors[i] - b * lanczos_vectors[i - 1]
 
         if not converged:
@@ -82,8 +98,11 @@ class Krylov(KrylovIntegrator):
                 to precision in allotted number of steps."
             )
 
-        result = lanczos_vectors[0] * weights[0]
+        result = lanczos_vectors[0] * weights[:, 0].view(-1, 1, 1)
         for i in range(1, len(lanczos_vectors)):
-            result += lanczos_vectors[i] * weights[i]
+            result += lanczos_vectors[i] * weights[:, i].view(-1, 1, 1)
+
+        # move leading batch dimension back to trailing dimension
+        result = result.squeeze(-1).T
 
         return result


### PR DESCRIPTION
This is a PR to address Issue 295: [Optimize Krylov solver for batched calculations](https://github.com/pasqal-io/pyqtorch/issues/295).

### :construction:  Changes to Existing Features:

* Modified `Krylov.step()` to handle `state` with a dimension `1`. This required adding a batch dimension to all relevant linear algebra operations in this method.

* Removed the for-loop based batching used in the `KrylovIntegrator.run()` function, and replaced it with a call to `integrate()`, instead passing the full batch size in dimension `1` of the `y` argument.

---
### :spiral_notepad: Notes:

* The batched dimension yields an expected speedup roughly proportional to the batch size if the batch size is small. As anecdotal evidence, running ```hatch -e tests run pytest tests/test_analog.py::test_timedependent[krylov_se-True-5-duration]``` on my machine takes roughly 0.83 seconds (using a batch size of 5) versus 7.29s when using the for-loop based approach.

* When using batching, the convergence criteria of of the method is currently limited by the maximum error across all batch items. If any batch items require many iterations to converge, the entire batch may experience this slowdown. I don't anticipate this being a major issue, since I think the Hamiltonian tends to be the source of any ill-conditioning, not the initial states. As far as I am aware, all batched initial conditions are evolved under the same Hamiltonian.